### PR TITLE
Fix to bug when using SVGImage with ui:binder

### DIFF
--- a/src/main/java/org/vectomatic/dom/svg/ui/SVGImage.java
+++ b/src/main/java/org/vectomatic/dom/svg/ui/SVGImage.java
@@ -115,7 +115,7 @@ public class SVGImage extends SVGWidget implements HasGraphicalHandlers, HasAllM
 	 */
 	public SVGImage() {
 	}
-	public SVGImage(SVGResource resource) {
+	@UiConstructor public SVGImage(SVGResource resource) {
 		setResource(resource);
 	}
 	public SVGImage(OMSVGSVGElement svgElement) {


### PR DESCRIPTION
In the original version the following ui:binder code doesn’t work

<svg:SVGImage ui:field="fbutton" resource="{commonRes.iconF}" width="32px"/>

since it seems that gwt, on ui creation, tries to set width before setting the resource, which triggers a null pointer exception. By declaring the constructor using @UIConstructor tag, gwt sets the specified resource on construction, which is before setting the other attributes specified in the ui:binder tag (in the example, the attribute ‘width’).
